### PR TITLE
Fail message fix

### DIFF
--- a/src/steps/contact-field-equals.ts
+++ b/src/steps/contact-field-equals.ts
@@ -48,7 +48,7 @@ export class ContactFieldEquals extends BaseStep implements StepInterface {
         return this.fail('Expected %s to be %s, but it was actually %s.', [
           field,
           expectation,
-          contact.properties[field],
+          contact.properties[field].value,
         ]);
       }
     } catch (e) {

--- a/test/scenarios/hubspot-contact-scenario.yml
+++ b/test/scenarios/hubspot-contact-scenario.yml
@@ -8,6 +8,7 @@ steps:
         email: hubspot@sample.com
         lastname: Doe
         company: Sample Company
+- step: the email field on hubspot contact hubspot@sample.com should be hubspot@sample.com
 - step: the company field on hubspot contact hubspot@sample.com should be Sample Company
 - step: the lastname field on hubspot contact hubspot@sample.com should be Doe
 - step: delete the hubspot@sample.com hubspot contact


### PR DESCRIPTION
Fixed the hubspot step: `contact-field-equals` from displaying `[object Object]` when failing. This is due to non-invocation of `value` property from the field.