### PR TITLE
Optionally support OAuth-based authentication

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -215,6 +215,15 @@
       "integrity": "sha512-VRw2xEGbll3ZiTQ4J02/hUjNqZoue1bMhoo2dgM2LXjDdyaq4q80HgBDHwpI0/VKlo4Eg+BavyQMv/NYgTetzA==",
       "dev": true
     },
+    "@types/chai-as-promised": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/@types/chai-as-promised/-/chai-as-promised-7.1.2.tgz",
+      "integrity": "sha512-PO2gcfR3Oxa+u0QvECLe1xKXOqYTzCmWf0FhLhjREoW3fPAVamjihL7v1MOVLJLsnAMdLcjkfrs01yvDMwVK4Q==",
+      "dev": true,
+      "requires": {
+        "@types/chai": "*"
+      }
+    },
     "@types/google-protobuf": {
       "version": "3.7.1",
       "resolved": "https://registry.npmjs.org/@types/google-protobuf/-/google-protobuf-3.7.1.tgz",
@@ -845,6 +854,15 @@
         "get-func-name": "^2.0.0",
         "pathval": "^1.1.0",
         "type-detect": "^4.0.5"
+      }
+    },
+    "chai-as-promised": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/chai-as-promised/-/chai-as-promised-7.1.1.tgz",
+      "integrity": "sha512-azL6xMoi+uxu6z4rhWQ1jbdUhOMhis2PvscD/xjLqNMkv3BPPp2JyyuTHOrf9BOosGpNQ11v6BKv/g57RXbiaA==",
+      "dev": true,
+      "requires": {
+        "check-error": "^1.0.2"
       }
     },
     "chalk": {

--- a/package.json
+++ b/package.json
@@ -39,11 +39,13 @@
   },
   "devDependencies": {
     "@types/chai": "^4.1.7",
+    "@types/chai-as-promised": "^7.1.2",
     "@types/google-protobuf": "^3.2.7",
     "@types/mocha": "^5.2.7",
     "@types/needle": "^2.0.4",
     "@types/node": "^12.0.4",
     "chai": "^4.2.0",
+    "chai-as-promised": "^7.1.1",
     "check-engine": "^1.8.1",
     "grpc-tools": "^1.7.3",
     "grpc_tools_node_protoc_ts": "^2.5.1",

--- a/src/client/client-wrapper.ts
+++ b/src/client/client-wrapper.ts
@@ -12,11 +12,32 @@ class ClientWrapper {
   }];
 
   client: Hubspot.default;
+  clientReady: Promise<boolean>;
 
   constructor(auth: grpc.Metadata, clientConstructor = Hubspot.default) {
-    this.client = new clientConstructor({
-      apiKey: auth.get('apiKey').toString(),
-    });
+    // Support OAuth-based authentication under the hood.
+    if (auth.get('refreshToken').toString()) {
+      this.client = new clientConstructor({
+        clientId: auth.get('clientId').toString(),
+        clientSecret: auth.get('clientSecret').toString(),
+        redirectUri: auth.get('redirectUri').toString(),
+        refreshToken: auth.get('refreshToken').toString(),
+      });
+      this.clientReady = new Promise((resolve, reject) => {
+        // @todo use normal method call once this issue is resolved:
+        // https://github.com/MadKudu/node-hubspot/issues/193
+        this.client['refreshAccessToken']()
+          .then(() => resolve(true))
+          .catch(e => reject(Error(`Authentication error, unable to refresh access token: ${e.toString()}`)));
+      });
+    } else {
+      // But fallback to API Key-based authentication, which is what is
+      // officially supported.
+      this.client = new clientConstructor({
+        apiKey: auth.get('apiKey').toString(),
+      });
+      this.clientReady = Promise.resolve(true);
+    }
   }
 }
 

--- a/src/client/mixins/contact-aware.ts
+++ b/src/client/mixins/contact-aware.ts
@@ -1,9 +1,11 @@
 import * as hubspot from 'hubspot';
 
 export class ContactAwareMixin {
+  clientReady: Promise<boolean>;
   client: hubspot.default;
 
   public async getContactByEmail(email: string): Promise<Object> {
+    await this.clientReady;
     return new Promise((resolve, reject) => {
       this.client.contacts.getByEmail(email).then((result) => {
         resolve(result);
@@ -14,6 +16,7 @@ export class ContactAwareMixin {
   }
 
   public async createOrUpdateContact(email: string, contact: Object): Promise<Object> {
+    await this.clientReady;
     return new Promise((resolve, reject) => {
       this.client.contacts.createOrUpdate(email, contact).then((result) => {
         resolve(result);
@@ -24,6 +27,7 @@ export class ContactAwareMixin {
   }
 
   public async deleteContactByEmail(email: string): Promise<Object> {
+    await this.clientReady;
     return new Promise(async (resolve, reject) => {
       try {
         const contact = await this.client.contacts.getByEmail(email);

--- a/test/client/client-wrapper.ts
+++ b/test/client/client-wrapper.ts
@@ -1,17 +1,87 @@
 import * as chai from 'chai';
 import { default as sinon } from 'ts-sinon';
 import * as sinonChai from 'sinon-chai';
+import * as justForIdeTypeHinting from 'chai-as-promised';
 import 'mocha';
 
 import { ClientWrapper } from '../../src/client/client-wrapper';
 import { Metadata } from 'grpc';
 
 chai.use(sinonChai);
+chai.use(require('chai-as-promised'));
 
 describe('ClientWrapper', () => {
-  // const expect = chai.expect;
-  // let needleConstructorStub: any;
-  // let metadata: Metadata;
-  // let clientWrapperUnderTest: ClientWrapper;
+  const expect = chai.expect;
+  let hubspotClientStub: any;
+  let hubspotConstructorStub: any;
+  let metadata: Metadata;
+  let clientWrapperUnderTest: ClientWrapper;
+
+  beforeEach(() => {
+    hubspotClientStub = {
+      refreshAccessToken: sinon.stub(),
+    };
+    hubspotConstructorStub = sinon.stub();
+    hubspotConstructorStub.returns(hubspotClientStub)
+  });
+
+  it('authenticates with api key', () => {
+    // Construct grpc metadata and assert the client was authenticated.
+    const expectedCallArgs = {
+      apiKey: 'some-api-key',
+    };
+    metadata = new Metadata();
+    metadata.add('apiKey', expectedCallArgs.apiKey);
+
+    // Assert that the underlying API client was authenticated correctly.
+    clientWrapperUnderTest = new ClientWrapper(metadata, hubspotConstructorStub);
+    expect(hubspotConstructorStub).to.have.been.calledWith(expectedCallArgs);
+    expect(clientWrapperUnderTest.clientReady).to.eventually.equal(true);
+  });
+
+  it('authenticates with oauth details', () => {
+    // Construct grpc metadata and assert the client was authenticated.
+    const expectedCallArgs = {
+      clientId: 'a-client-id',
+      clientSecret: 'a-client-secret',
+      refreshToken: 'a-refresh-token',
+      redirectUri: 'https://example.com/oauth-callback'
+    };
+    metadata = new Metadata();
+    metadata.add('clientId', expectedCallArgs.clientId);
+    metadata.add('clientSecret', expectedCallArgs.clientSecret);
+    metadata.add('refreshToken', expectedCallArgs.refreshToken);
+    metadata.add('redirectUri', expectedCallArgs.redirectUri);
+
+    // Set the refresh access token method to resolve.
+    hubspotClientStub.refreshAccessToken.resolves();
+
+    // Assert that the underlying API client was authenticated correctly.
+    clientWrapperUnderTest = new ClientWrapper(metadata, hubspotConstructorStub);
+    expect(hubspotConstructorStub).to.have.been.calledWith(expectedCallArgs);
+    expect(clientWrapperUnderTest.clientReady).to.eventually.equal(true);
+  });
+
+  it('aborts client readiness when auth token refresh fails', () => {
+    // Construct grpc metadata and assert the client was authenticated.
+    const expectedCallArgs = {
+      clientId: 'a-client-id',
+      clientSecret: 'a-client-secret',
+      refreshToken: 'a-refresh-token',
+      redirectUri: 'https://example.com/oauth-callback'
+    };
+    metadata = new Metadata();
+    metadata.add('clientId', expectedCallArgs.clientId);
+    metadata.add('clientSecret', expectedCallArgs.clientSecret);
+    metadata.add('refreshToken', expectedCallArgs.refreshToken);
+    metadata.add('redirectUri', expectedCallArgs.redirectUri);
+
+    // Set the refresh access token method to reject.
+    hubspotClientStub.refreshAccessToken.rejects();
+
+    // Assert that the underlying API client was authenticated correctly.
+    clientWrapperUnderTest = new ClientWrapper(metadata, hubspotConstructorStub);
+    expect(clientWrapperUnderTest.clientReady).to.eventually.be.rejected;
+  });
 
 });


### PR DESCRIPTION
Allows the Cog to use OAuth-based authentication when provided the requisite details in grpc metadata (e.g. `refreshToken`, `clientId`, `clientSecret`, and `redirectUri`).

API Key-based authentication is unaffected.