### PR TITLE
Changed expression for HubSpot contact enrollment validation

### DIFF
--- a/src/steps/workflow-contact-enrolled.ts
+++ b/src/steps/workflow-contact-enrolled.ts
@@ -6,7 +6,7 @@ import { Step, FieldDefinition, StepDefinition } from '../proto/cog_pb';
 export class ContactEnrolledToWorkflowStep extends BaseStep implements StepInterface {
 
   protected stepName: string = 'Check Workflow Enrollment of a HubSpot Contact';
-  protected stepExpression: string = 'the (?<email>.+) hubspot contact should be enrolled in workflow (?<workflow>.+)';
+  protected stepExpression: string = 'the (?<email>.+) hubspot contact should currently be enrolled in workflow (?<workflow>.+)';
   protected stepType: StepDefinition.Type = StepDefinition.Type.VALIDATION;
 
   protected expectedFields: Field[] = [{

--- a/test/scenarios/workflow-validate-contact-enrollment.yml
+++ b/test/scenarios/workflow-validate-contact-enrollment.yml
@@ -7,6 +7,6 @@ steps:
     contact:
       email: test@automatoninc.com
 - step: When I enroll the test@automatoninc.com hubspot contact into workflow MQL and Email
-- step: Then the test@automatoninc.com hubspot contact should be enrolled in workflow 7267160
-- step: Then the test@automatoninc.com hubspot contact should be enrolled in workflow MQL and Email
+- step: Then the test@automatoninc.com hubspot contact should currently be enrolled in workflow 7267160
+- step: Then the test@automatoninc.com hubspot contact should currently be enrolled in workflow MQL and Email
 - step: Finally, delete the test@automatoninc.com HubSpot Contact

--- a/test/steps/workflow-contact-enrolled.ts
+++ b/test/steps/workflow-contact-enrolled.ts
@@ -28,7 +28,7 @@ describe('ContactEnrolledToWorkflowStep', () => {
       const stepDef: StepDefinition = stepUnderTest.getDefinition();
       expect(stepDef.getStepId()).to.equal('ContactEnrolledToWorkflowStep');
       expect(stepDef.getName()).to.equal('Check Workflow Enrollment of a HubSpot Contact');
-      expect(stepDef.getExpression()).to.equal('the (?<email>.+) hubspot contact should be enrolled in workflow (?<workflow>.+)');
+      expect(stepDef.getExpression()).to.equal('the (?<email>.+) hubspot contact should currently be enrolled in workflow (?<workflow>.+)');
       expect(stepDef.getType()).to.equal(StepDefinition.Type.VALIDATION);
     });
 


### PR DESCRIPTION
Changed expression for `HubSpot` contact enrollment validation