### PR TITLE
String Fixes for HubSpot workflows

### DIFF
--- a/src/steps/workflow-contact-enrolled.ts
+++ b/src/steps/workflow-contact-enrolled.ts
@@ -46,7 +46,7 @@ export class ContactEnrolledToWorkflowStep extends BaseStep implements StepInter
         return this.fail('The Contact %s is not enrolled in the given workflow %s. Contact is enrolled in: %s', [
           email,
           workflow,
-          workflows.map(f => f.name).join(', '),
+          workflows.map(f => f[property]).join(', '),
         ]);
       }
 


### PR DESCRIPTION
For bug #16 

This should:
1. (Validation) Make the step faithful to user's input. For example when the user inputs an id, all the workflow will be displayed with their Ids. Same with name.
2. (Enrollment) Same behavior. If enrolled with id e.g. 7123891, then the message should be something similar: `... successfully enrolled to 7123891`. Same with name.