### PR TITLE
Removed all whitespace removal for operators

### DIFF
--- a/src/steps/contact-field-equals.ts
+++ b/src/steps/contact-field-equals.ts
@@ -48,12 +48,12 @@ export class ContactFieldEquals extends BaseStep implements StepInterface {
       }
 
       if (this.compare(operator, contact.properties[field].value, expectation)) {
-        return this.pass(this.operatorSuccessMessages[operator.replace(/\s/g, '').toLowerCase()], [
+        return this.pass(this.operatorSuccessMessages[operator], [
           field,
           expectation,
         ]);
       } else {
-        return this.fail(this.operatorFailMessages[operator.replace(/\s/g, '').toLowerCase()], [
+        return this.fail(this.operatorFailMessages[operator], [
           field,
           expectation,
           contact.properties[field].value,


### PR DESCRIPTION
The `util` had a change in determining proper `pass/fail` messages as seen on:

https://github.com/run-crank/typescript-cog-utilities/blob/master/src/utils/compare.ts#L4

There are steps affected that still has the `.replace(/\s/g, '').toLowerCase()` code which removes all space and then therefore cannot be mapped to the updated pass fail messages in the `util` (which now contains space)