### PR TITLE
Handled epoch dates for HubSpot

### DIFF
--- a/src/client/client-wrapper.ts
+++ b/src/client/client-wrapper.ts
@@ -3,6 +3,7 @@ import * as Hubspot from 'hubspot';
 import { Field } from '../core/base-step';
 import { FieldDefinition } from '../proto/cog_pb';
 import { ContactAwareMixin, WorkflowAwareMixin } from './mixins';
+import { DateAwareMixin } from './mixins/date-aware';
 
 class ClientWrapper {
   public static expectedAuthFields: Field[] = [{
@@ -41,9 +42,9 @@ class ClientWrapper {
   }
 }
 
-interface ClientWrapper extends ContactAwareMixin, WorkflowAwareMixin {}
+interface ClientWrapper extends ContactAwareMixin, WorkflowAwareMixin, DateAwareMixin {}
 
-applyMixins(ClientWrapper, [ContactAwareMixin, WorkflowAwareMixin]);
+applyMixins(ClientWrapper, [ContactAwareMixin, WorkflowAwareMixin, DateAwareMixin]);
 
 function applyMixins(derivedCtor: any, baseCtors: any[]) {
   baseCtors.forEach((baseCtor) => {

--- a/src/client/mixins/date-aware.ts
+++ b/src/client/mixins/date-aware.ts
@@ -1,0 +1,60 @@
+export class DateAwareMixin {
+
+  public isDate(object: string, field: string): boolean {
+    const fields = this.getDateFields()[object];
+    return fields.includes(field);
+  }
+
+  public toDate(epoch: number): string {
+    const result = new Date(+epoch);
+    return result.toISOString();
+  }
+
+  public getDateFields() {
+    return {
+      contact: [
+        'first_conversion_date',
+        'first_deal_created_date',
+        'hs_content_membership_registered_at',
+        'hs_content_membership_registration_email_sent_at',
+        'hs_createdate',
+        'hs_document_last_revisited',
+        'hs_email_recipient_fatigue_recovery_time',
+        'hs_feedback_last_survey_date',
+        'hs_last_sales_activity_date',
+        'hs_lastmodifieddate',
+        'hs_sales_email_last_clicked',
+        'hs_sales_email_last_opened',
+        'hubspot_owner_assigneddate',
+        'lastmodifieddate',
+        'recent_conversion_date',
+        'recent_deal_close_date',
+        'salesforcelastsynctime',
+        'hs_analytics_first_timestamp',
+        'hs_email_last_send_date',
+        'engagements_last_meeting_booked',
+        'hs_analytics_first_visit_timestamp',
+        'hs_email_last_open_date',
+        'hs_sales_email_last_replied',
+        'notes_last_contacted',
+        'notes_last_updated',
+        'notes_next_activity_date',
+        'hs_analytics_last_timestamp',
+        'hs_email_last_click_date',
+        'hs_analytics_last_visit_timestamp',
+        'hs_email_first_send_date',
+        'hs_email_first_open_date',
+        'hs_email_first_click_date',
+        'closedate',
+        'hs_lifecyclestage_lead_date',
+        'hs_lifecyclestage_marketingqualifiedlead_date',
+        'hs_lifecyclestage_opportunity_date',
+        'hs_lifecyclestage_salesqualifiedlead_date',
+        'createdate',
+        'hs_lifecyclestage_evangelist_date',
+        'hs_lifecyclestage_customer_date',
+        'hs_lifecyclestage_subscriber_date',
+        'hs_lifecyclestage_other_date'],
+    };
+  }
+}

--- a/src/client/mixins/date-aware.ts
+++ b/src/client/mixins/date-aware.ts
@@ -1,60 +1,21 @@
 export class DateAwareMixin {
+  public isDate(value: any): boolean {
+    let result = false;
+    const minEpochValue = 605692800;
+    const today = new Date();
+    const tenYearsFromNow = today.setFullYear(today.getFullYear() + 10).valueOf();
 
-  public isDate(object: string, field: string): boolean {
-    const fields = this.getDateFields()[object];
-    return fields.includes(field);
+    const isNumber = !isNaN(value);
+    const isEpoch = +value > minEpochValue;
+    const withinTenYears = +value < tenYearsFromNow;
+
+    result = isNumber && isEpoch && withinTenYears;
+
+    return result;
   }
 
   public toDate(epoch: number): string {
     const result = new Date(+epoch);
     return result.toISOString();
-  }
-
-  public getDateFields() {
-    return {
-      contact: [
-        'first_conversion_date',
-        'first_deal_created_date',
-        'hs_content_membership_registered_at',
-        'hs_content_membership_registration_email_sent_at',
-        'hs_createdate',
-        'hs_document_last_revisited',
-        'hs_email_recipient_fatigue_recovery_time',
-        'hs_feedback_last_survey_date',
-        'hs_last_sales_activity_date',
-        'hs_lastmodifieddate',
-        'hs_sales_email_last_clicked',
-        'hs_sales_email_last_opened',
-        'hubspot_owner_assigneddate',
-        'lastmodifieddate',
-        'recent_conversion_date',
-        'recent_deal_close_date',
-        'salesforcelastsynctime',
-        'hs_analytics_first_timestamp',
-        'hs_email_last_send_date',
-        'engagements_last_meeting_booked',
-        'hs_analytics_first_visit_timestamp',
-        'hs_email_last_open_date',
-        'hs_sales_email_last_replied',
-        'notes_last_contacted',
-        'notes_last_updated',
-        'notes_next_activity_date',
-        'hs_analytics_last_timestamp',
-        'hs_email_last_click_date',
-        'hs_analytics_last_visit_timestamp',
-        'hs_email_first_send_date',
-        'hs_email_first_open_date',
-        'hs_email_first_click_date',
-        'closedate',
-        'hs_lifecyclestage_lead_date',
-        'hs_lifecyclestage_marketingqualifiedlead_date',
-        'hs_lifecyclestage_opportunity_date',
-        'hs_lifecyclestage_salesqualifiedlead_date',
-        'createdate',
-        'hs_lifecyclestage_evangelist_date',
-        'hs_lifecyclestage_customer_date',
-        'hs_lifecyclestage_subscriber_date',
-        'hs_lifecyclestage_other_date'],
-    };
   }
 }

--- a/src/steps/contact-field-equals.ts
+++ b/src/steps/contact-field-equals.ts
@@ -47,7 +47,10 @@ export class ContactFieldEquals extends BaseStep implements StepInterface {
         ]);
       }
 
-      if (this.compare(operator, contact.properties[field].value, expectation)) {
+      const value = contact.properties[field].value;
+      const actual = this.client.isDate('contact', field) ? this.client.toDate(value) : value;
+
+      if (this.compare(operator, actual, expectation)) {
         return this.pass(this.operatorSuccessMessages[operator], [
           field,
           expectation,
@@ -56,7 +59,7 @@ export class ContactFieldEquals extends BaseStep implements StepInterface {
         return this.fail(this.operatorFailMessages[operator], [
           field,
           expectation,
-          contact.properties[field].value,
+          actual,
         ]);
       }
     } catch (e) {

--- a/src/steps/contact-field-equals.ts
+++ b/src/steps/contact-field-equals.ts
@@ -48,7 +48,7 @@ export class ContactFieldEquals extends BaseStep implements StepInterface {
       }
 
       const value = contact.properties[field].value;
-      const actual = this.client.isDate('contact', field) ? this.client.toDate(value) : value;
+      const actual = this.client.isDate(value) ? this.client.toDate(value) : value;
 
       if (this.compare(operator, actual, expectation)) {
         return this.pass(this.operatorSuccessMessages[operator], [

--- a/test/client/client-wrapper.ts
+++ b/test/client/client-wrapper.ts
@@ -84,4 +84,17 @@ describe('ClientWrapper', () => {
     expect(clientWrapperUnderTest.clientReady).to.eventually.be.rejected;
   });
 
+  it('should identify date values', () => {
+    const validEpoch = 1589245171;
+    metadata = new Metadata();
+    clientWrapperUnderTest = new ClientWrapper(metadata, hubspotConstructorStub);
+    expect(clientWrapperUnderTest.isDate(validEpoch)).to.equal(true);
+  });
+
+  it('should convert epoch dates to YYYY-MM-DD format', () => {
+    const validEpoch = 1579245603000;
+    metadata = new Metadata();
+    clientWrapperUnderTest = new ClientWrapper(metadata, hubspotConstructorStub);
+    expect(clientWrapperUnderTest.toDate(validEpoch)).to.equal('2020-01-17T07:20:03.000Z');
+  });
 });

--- a/test/scenarios/Contact CRUD.crank.yml
+++ b/test/scenarios/Contact CRUD.crank.yml
@@ -17,5 +17,5 @@ steps:
       company: '{{test.company}}'
 - step: Then the email field on HubSpot Contact {{test.email}} should be {{test.email}}
 - step: And the company field on HubSpot Contact {{test.email}} should be {{test.company}}
-- step: And the lastname field on HubSpot Contact {{test.email}} should be {{test.lastname}}
+- step: And the createdate field on HubSpot Contact {{test.email}} should be greater than 2019-01-01
 - step: Finally, delete the {{test.email}} HubSpot Contact

--- a/test/steps/contact-field-equals.ts
+++ b/test/steps/contact-field-equals.ts
@@ -108,6 +108,7 @@ describe('ContactFieldEquals', () => {
             email: expectedEmail,
             lastname: { value: expectedLastname },
             age: { value: 25 },
+            createdate: { value: 1579245170 },
           },
         }));
       });

--- a/test/steps/contact-field-equals.ts
+++ b/test/steps/contact-field-equals.ts
@@ -19,6 +19,8 @@ describe('ContactFieldEquals', () => {
     protoStep = new ProtoStep();
     clientWrapperStub = sinon.stub();
     clientWrapperStub.getContactByEmail = sinon.stub();
+    clientWrapperStub.isDate = sinon.stub();
+    clientWrapperStub.isDate.returns(false);
     stepUnderTest = new Step(clientWrapperStub);
   });
 

--- a/test/steps/contact-field-equals.ts
+++ b/test/steps/contact-field-equals.ts
@@ -99,6 +99,7 @@ describe('ContactFieldEquals', () => {
           email: expectedEmail,
           expectation: expectedLastname,
           field: 'lastname',
+          operator: 'be',
         }));
         clientWrapperStub.getContactByEmail.returns(Promise.resolve({
           properties: {
@@ -149,6 +150,7 @@ describe('ContactFieldEquals', () => {
           email: expectedEmail,
           expectation: 'wrong expectation',
           field: 'lastname',
+          operator: 'be',
         }));
         clientWrapperStub.getContactByEmail.returns(Promise.resolve({
           properties: {


### PR DESCRIPTION
For #35,

This implementation hard codes all possible `datetime` fields that came from `http://.../contact/properties` describe endpoint provided by the `HubSpot` api.

On the average, the request to get all contact properties took `>550ms`. Also `200kb` in size (`json`)

The approach was:
1. Create a `DateAware` mixin that will "know" all `datetime` fields per `object/endpoint` e.g. `contact`
2. Expose `isDate` and `toDate` functionality