### PR TITLE
Fixed workflow table record from displaying all columns/properties

### DIFF
--- a/src/steps/workflow/workflow-enroll.ts
+++ b/src/steps/workflow/workflow-enroll.ts
@@ -85,8 +85,7 @@ export class EnrollContactToWorkflowStep extends BaseStep implements StepInterfa
         const workflows = await this.client.findWorkflowByName(workflow);
 
         if (workflows.length > 1) {
-          const headers = {};
-          Object.keys(workflows[0]).forEach(key => headers[key] = key);
+          const headers = { name: 'Name', id: 'Id', type: 'Type', description: 'Description' };
 
           const table = workflows.map((workflow) => {
             return {


### PR DESCRIPTION
Fixed a bug when more than 1 workflows are found with the provided name from displaying all properties as the table columns