### PR TITLE
PII suppression in step messages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -196,9 +196,9 @@
       }
     },
     "@run-crank/utilities": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@run-crank/utilities/-/utilities-0.5.0.tgz",
-      "integrity": "sha512-gEDbF8hl99dFtg3kN7hEnM4E82RAnX3+8HATXbPWiVIr7zop5SDIL6mlk/QxpHecOlYgM4jebHJ+dqCTdotqVg==",
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/@run-crank/utilities/-/utilities-0.5.1.tgz",
+      "integrity": "sha512-U9YS6zsu7/PCtJl6/PZRcnS8Dh3r4CWLyAg01MhUp7e5rkW2OXZUdosO0RcRYfQHWjs6flz8R2ATTo7TD/jsrQ==",
       "requires": {
         "csv-string": "^4.0.1",
         "moment": "^2.24.0"
@@ -1425,9 +1425,9 @@
       }
     },
     "csv-string": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/csv-string/-/csv-string-4.1.0.tgz",
-      "integrity": "sha512-67UM45fosQvvh+HUvC8iNgg2B4UHWJ5Qud7TWy1EcbIQ9levAFKWudMk2k8U3LgXZP/Drr6eBwBwbSWq2N8HZA=="
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/csv-string/-/csv-string-4.1.1.tgz",
+      "integrity": "sha512-KGvaJEZEdh2O/EVvczwbPLqJZtSQaWQ4cEJbiOJEG4ALq+dBBqNmBkRXTF4NV79V25+XYtiqbco1IWrmHLm5FQ=="
     },
     "dashdash": {
       "version": "1.14.1",

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "typescript": "^3.5.1"
   },
   "dependencies": {
-    "@run-crank/utilities": "^0.5.0",
+    "@run-crank/utilities": "^0.5.1",
     "google-protobuf": "^3.8.0",
     "grpc": "^1.21.1",
     "hubspot": "^2.3.14",

--- a/src/core/base-step.ts
+++ b/src/core/base-step.ts
@@ -86,8 +86,8 @@ export abstract class BaseStep {
     return stepDefinition;
   }
 
-  assert(operator: string, actualValue: string, value: string, field: string): util.AssertionResult {
-    return util.assert(operator, actualValue, value, field);
+  assert(operator: string, actualValue: string, value: string, field: string, piiLevel: string = null): util.AssertionResult {
+    return util.assert(operator, actualValue, value, field, piiLevel);
   }
 
   protected pass(message: string, messageArgs: any[] = [], records: StepRecord[] = []): RunStepResponse {

--- a/src/steps/company/company-field-equals.ts
+++ b/src/steps/company/company-field-equals.ts
@@ -66,7 +66,7 @@ export class CompanyFieldEquals extends BaseStep implements StepInterface {
 
       company['id'] = id;
       const records = this.createRecords(company, stepData['__stepOrder']);
-      const result = this.assert(operator, actual.value, expectation, field);
+      const result = this.assert(operator, actual.value, expectation, field, stepData['__piiSuppressionLevel']);
 
       return result.valid ? this.pass(result.message, [], records)
         : this.fail(result.message, [], records);

--- a/src/steps/contact/contact-field-equals-by-id.ts
+++ b/src/steps/contact/contact-field-equals-by-id.ts
@@ -74,7 +74,7 @@ export class ContactFieldEqualsByIdStep extends BaseStep implements StepInterfac
       const actual = this.client.isDate(value) ? this.client.toDate(value) : value;
 
       const records = this.createRecords(contact, stepData['__stepOrder']);
-      const result = this.assert(operator, actual, expectation, field);
+      const result = this.assert(operator, actual, expectation, field, stepData['__piiSuppressionLevel']);
 
       return result.valid ? this.pass(result.message, [], records)
         : this.fail(result.message, [], records);

--- a/src/steps/contact/contact-field-equals.ts
+++ b/src/steps/contact/contact-field-equals.ts
@@ -74,7 +74,7 @@ export class ContactFieldEquals extends BaseStep implements StepInterface {
       const actual = this.client.isDate(value) ? this.client.toDate(value) : value;
 
       const records = this.createRecords(contact, stepData['__stepOrder']);
-      const result = this.assert(operator, actual, expectation, field);
+      const result = this.assert(operator, actual, expectation, field, stepData['__piiSuppressionLevel']);
 
       return result.valid ? this.pass(result.message, [], records)
         : this.fail(result.message, [], records);

--- a/src/steps/deal/deal-field-equals.ts
+++ b/src/steps/deal/deal-field-equals.ts
@@ -66,7 +66,7 @@ export class DealFieldEquals extends BaseStep implements StepInterface {
 
       deal['id'] = id;
       const records = this.createRecords(deal, stepData['__stepOrder']);
-      const result = this.assert(operator, actual.value, expectation, field);
+      const result = this.assert(operator, actual.value, expectation, field, stepData['__piiSuppressionLevel']);
 
       return result.valid ? this.pass(result.message, [], records)
         : this.fail(result.message, [], records);

--- a/src/steps/marketing-event/marketing-event-field-equals.ts
+++ b/src/steps/marketing-event/marketing-event-field-equals.ts
@@ -91,7 +91,7 @@ export class MarketingEventFieldEquals extends BaseStep implements StepInterface
         actual = actual.split('Z')[0];
       }
       const records = this.createRecords(marketingEvent, stepData['__stepOrder']);
-      const result = this.assert(operator, actual, expectation, field);
+      const result = this.assert(operator, actual, expectation, field, stepData['__piiSuppressionLevel']);
 
       return result.valid ? this.pass(result.message, [], records)
         : this.fail(result.message, [], records);

--- a/src/steps/product/product-field-equals.ts
+++ b/src/steps/product/product-field-equals.ts
@@ -66,7 +66,7 @@ export class ProductFieldEquals extends BaseStep implements StepInterface {
 
       product['id'] = id;
       const records = this.createRecords(product, stepData['__stepOrder']);
-      const result = this.assert(operator, actual, expectation, field);
+      const result = this.assert(operator, actual, expectation, field, stepData['__piiSuppressionLevel']);
 
       return result.valid ? this.pass(result.message, [], records)
         : this.fail(result.message, [], records);

--- a/src/steps/quote/quote-field-equals.ts
+++ b/src/steps/quote/quote-field-equals.ts
@@ -74,7 +74,7 @@ export class QuoteFieldEquals extends BaseStep implements StepInterface {
 
       quote['id'] = id;
       const records = this.createRecords(quote, stepData['__stepOrder']);
-      const result = this.assert(operator, actual, expectation, field);
+      const result = this.assert(operator, actual, expectation, field, stepData['__piiSuppressionLevel']);
 
       return result.valid ? this.pass(result.message, [], records)
         : this.fail(result.message, [], records);

--- a/src/steps/ticket/ticket-field-equals.ts
+++ b/src/steps/ticket/ticket-field-equals.ts
@@ -78,7 +78,7 @@ export class TicketFieldEquals extends BaseStep implements StepInterface {
 
       ticket['id'] = id;
       const records = this.createRecords(ticket, stepData['__stepOrder']);
-      const result = this.assert(operator, actual, expectation, field);
+      const result = this.assert(operator, actual, expectation, field, stepData['__piiSuppressionLevel']);
 
       return result.valid ? this.pass(result.message, [], records)
         : this.fail(result.message, [], records);


### PR DESCRIPTION
- Update typescript cog utilities
- Some step messages will have PII removed if a "__piiSuppressionLevel" is passed in the stepData