### PR TITLE
Bug Fix - Provided backup null value for workflow description

### DIFF
--- a/src/steps/workflow/workflow-contact-enrolled.ts
+++ b/src/steps/workflow/workflow-contact-enrolled.ts
@@ -100,9 +100,9 @@ export class ContactEnrolledToWorkflowStep extends BaseStep implements StepInter
           const table = workflows.map((workflow) => {
             return {
               id: workflow.id,
-              type: workflow.type,
-              name: workflow.name,
-              description: workflow.description,
+              type: workflow.type || null,
+              name: workflow.name || null,
+              description: workflow.description || null,
             };
           });
           workflowRecord = this.table('matchedWorkflows', 'Matched Workflows', headers, table);
@@ -135,7 +135,7 @@ export class ContactEnrolledToWorkflowStep extends BaseStep implements StepInter
 
   createContactRecord(contact): StepRecord {
     const obj = {};
-    Object.keys(contact.properties).forEach(key => obj[key] = contact.properties[key].value);
+    Object.keys(contact.properties).forEach(key => obj[key] = contact.properties[key].value || null);
     obj['createdate'] = this.client.toDate(obj['createdate']);
     obj['lastmodifieddate'] = this.client.toDate(obj['lastmodifieddate']);
     const record = this.keyValue('contact', 'Checked Contact', obj);
@@ -145,9 +145,9 @@ export class ContactEnrolledToWorkflowStep extends BaseStep implements StepInter
   createWorkflowRecord(workflow) {
     const obj = {
       id: workflow.id,
-      type: workflow.type,
-      name: workflow.name,
-      description: workflow.description,
+      type: workflow.type || null,
+      name: workflow.name || null,
+      description: workflow.description || null,
     };
 
     return this.keyValue('workflow', 'Workflow Enrollment Candidate', obj);

--- a/src/steps/workflow/workflow-contact-enrolled.ts
+++ b/src/steps/workflow/workflow-contact-enrolled.ts
@@ -58,10 +58,6 @@ export class ContactEnrolledToWorkflowStep extends BaseStep implements StepInter
       field: 'type',
       type: FieldDefinition.Type.STRING,
       description: 'The Workflow\'s Type',
-    }, {
-      field: 'description',
-      type: FieldDefinition.Type.STRING,
-      description: 'The Workflow\'s Description',
     }],
     dynamicFields: false,
   }];
@@ -100,8 +96,8 @@ export class ContactEnrolledToWorkflowStep extends BaseStep implements StepInter
           const table = workflows.map((workflow) => {
             return {
               id: workflow.id,
-              type: workflow.type || null,
-              name: workflow.name || null,
+              type: workflow.type,
+              name: workflow.name,
               description: workflow.description || null,
             };
           });
@@ -135,7 +131,7 @@ export class ContactEnrolledToWorkflowStep extends BaseStep implements StepInter
 
   createContactRecord(contact): StepRecord {
     const obj = {};
-    Object.keys(contact.properties).forEach(key => obj[key] = contact.properties[key].value || null);
+    Object.keys(contact.properties).forEach(key => obj[key] = contact.properties[key].value);
     obj['createdate'] = this.client.toDate(obj['createdate']);
     obj['lastmodifieddate'] = this.client.toDate(obj['lastmodifieddate']);
     const record = this.keyValue('contact', 'Checked Contact', obj);
@@ -145,8 +141,8 @@ export class ContactEnrolledToWorkflowStep extends BaseStep implements StepInter
   createWorkflowRecord(workflow) {
     const obj = {
       id: workflow.id,
-      type: workflow.type || null,
-      name: workflow.name || null,
+      type: workflow.type,
+      name: workflow.name,
       description: workflow.description || null,
     };
 

--- a/src/steps/workflow/workflow-enroll.ts
+++ b/src/steps/workflow/workflow-enroll.ts
@@ -37,10 +37,6 @@ export class EnrollContactToWorkflowStep extends BaseStep implements StepInterfa
       field: 'type',
       type: FieldDefinition.Type.STRING,
       description: 'The Workflow\'s Type',
-    }, {
-      field: 'description',
-      type: FieldDefinition.Type.STRING,
-      description: 'The Workflow\'s Description',
     }],
     dynamicFields: false,
   }, {
@@ -90,7 +86,7 @@ export class EnrollContactToWorkflowStep extends BaseStep implements StepInterfa
               id: workflow.id,
               type: workflow.type,
               name: workflow.name,
-              description: workflow.description,
+              description: workflow.description || null,
             };
           });
           const workflowRecords = this.table('matchedWorkflows', 'Matched Workflows', headers, table);
@@ -134,7 +130,7 @@ export class EnrollContactToWorkflowStep extends BaseStep implements StepInterfa
       id: workflow.id,
       type: workflow.type,
       name: workflow.name,
-      description: workflow.description,
+      description: workflow.description || null,
     };
 
     return this.keyValue('workflow', 'Workflow Enrollment Candidate', obj);


### PR DESCRIPTION
This sets a backup value of null for workflow description in the workflow-contact-enroll.ts file. 

Some more context: This fixes a bug that happens when the evaluated workflows did not have a description. In this case, the this.table() and this.keyValue() methods will throw an 'Unexpected struct type' error because the description was undefined. Setting a backup value of null fixes this issue.