### PR TITLE
Check API usage step

### DIFF
--- a/src/client/caching-client-wrapper.ts
+++ b/src/client/caching-client-wrapper.ts
@@ -352,6 +352,10 @@ class CachingClientWrapper {
     return this.client.toEpoch(date);
   }
 
+  public getApiUsage() {
+    return this.client.getApiUsage();
+  }
+
   // Redis methods for get, set, and delete
   // -------------------------------------------------------------------
 

--- a/src/client/client-wrapper.ts
+++ b/src/client/client-wrapper.ts
@@ -16,6 +16,7 @@ import {
   TicketAwareMixin,
   WorkflowAwareMixin,
   ImportsAwareMixinV3,
+  StatsAwareMixinV3,
 } from './mixins';
 
 class ClientWrapper {
@@ -92,7 +93,8 @@ interface ClientWrapper extends
   QuoteAwareMixin,
   AssociationAwareMixin,
   ContactListAwareMixin,
-  ImportsAwareMixinV3 { }
+  ImportsAwareMixinV3,
+  StatsAwareMixinV3 { }
 
 applyMixins(ClientWrapper, [
   ContactAwareMixin,
@@ -107,6 +109,7 @@ applyMixins(ClientWrapper, [
   AssociationAwareMixin,
   ContactListAwareMixin,
   ImportsAwareMixinV3,
+  StatsAwareMixinV3,
 ]);
 
 function applyMixins(derivedCtor: any, baseCtors: any[]) {

--- a/src/client/mixins/index.ts
+++ b/src/client/mixins/index.ts
@@ -10,3 +10,4 @@ export * from './quote-aware';
 export * from './association-aware';
 export * from './contact-list-aware';
 export * from './imports-aware';
+export * from './stats-aware';

--- a/src/client/mixins/stats-aware.ts
+++ b/src/client/mixins/stats-aware.ts
@@ -1,0 +1,46 @@
+import { Client } from '@hubspot/api-client';
+import * as grpc from 'grpc';
+
+export class StatsAwareMixinV3 {
+  clientV3: Client;
+  connectToV3: () => Promise<void>;
+  auth: grpc.Metadata;
+
+  public async getApiUsage() {
+    // Get the daily API limit and limit remaining for a HubSpot Access Token.
+    //
+    // Oauth connections have unlimited daily API calls. This function will
+    // return 'unlimited' for the limit if an oauth connection is used.
+    //
+    // Private apps connected with an access token will return their api usage.
+    // The api usage values are pulled from the response headers when we make a
+    // do nothing request to GET /integrations/v1/me
+    //
+    // The https://api.hubapi.com/account-info/v3/api-usage/daily endpoint doesn't work.
+    // See: https://community.hubspot.com/t5/APIs-Integrations/Daily-API-Usage-data-get-API/m-p/797324
+
+    if (this.auth.get('refreshToken').toString()) {
+      return {
+        limit: 'unlimited',
+        remaining: 'unlimited',
+      };
+    }
+
+    try {
+      await this.connectToV3();
+      const response = await this.clientV3.apiRequest({
+        method: 'GET',
+        path: '/integrations/v1/me',
+      });
+
+      const limit = Number(response.headers.get('x-hubspot-ratelimit-daily'));
+      const remaining = Number(response.headers.get('x-hubspot-ratelimit-daily-remaining'));
+      return {
+        limit,
+        remaining,
+      };
+    } catch (e) {
+      throw new Error(`Error calling GET /integrations/v1/me: ${e.message}`);
+    }
+  }
+}

--- a/src/steps/stats/check-api-usage.ts
+++ b/src/steps/stats/check-api-usage.ts
@@ -1,0 +1,54 @@
+/*tslint:disable:no-else-after-return*/
+
+import { BaseStep, Field, StepInterface, ExpectedRecord } from '../../core/base-step';
+import { Step, FieldDefinition, StepDefinition, RecordDefinition } from '../../proto/cog_pb';
+
+export class CheckHubspotApiUsageStep extends BaseStep implements StepInterface {
+
+  protected stepName: string = 'Check daily HubSpot API usage';
+  protected stepExpression: string = 'there should be less than 90% usage of your daily HubSpot API limit';
+  protected stepType: StepDefinition.Type = StepDefinition.Type.VALIDATION;
+  protected actionList: string[] = ['check'];
+  protected targetObject: string = 'API Usage';
+  protected expectedFields: Field[] = [];
+  protected expectedRecords: ExpectedRecord[] = [{
+    id: 'requests',
+    type: RecordDefinition.Type.KEYVALUE,
+    fields: [{
+      field: 'apiUsage',
+      type: FieldDefinition.Type.NUMERIC,
+      description: 'Daily API Requests',
+    }],
+    dynamicFields: false,
+  }];
+
+  async executeStep(step: Step) {
+    try {
+      const apiUsage = (await this.client.getApiUsage());
+
+      if (apiUsage.limit && apiUsage.limit === 'unlimited') {
+        return this.pass('You are using oauth 2.0 to connect to HubSpot and may make unlimited API calls through Stack Moxie.', [], []);
+      }
+
+      const apiRequestsMade = apiUsage.limit - apiUsage.remaining;
+      const percentUsage = (apiRequestsMade / apiUsage.limit) * 100;
+
+      if (apiRequestsMade < (0.9 * apiUsage.limit)) {
+        return this.pass(
+          'You have used %d of your %d HubSpot API calls for today, which is %d%% of your daily API limit.',
+          [apiRequestsMade, apiUsage.limit, percentUsage],
+          [this.keyValue('requests', 'Checked API Usage', { apiUsage: apiRequestsMade })],
+        );
+      }
+      return this.fail(
+        'You have used %d of your %d HubSpot API calls for today, which is %d%% of your daily API limit.',
+        [apiRequestsMade, apiUsage.limit, percentUsage],
+        [this.keyValue('requests', 'Checked API Usage', { apiUsage: apiRequestsMade })],
+      );
+    } catch (e) {
+      return this.error('There was a problem checking the API Usage: %s', [e.toString()]);
+    }
+  }
+}
+
+export { CheckHubspotApiUsageStep as Step };

--- a/test/client/caching-client-wrapper.ts
+++ b/test/client/caching-client-wrapper.ts
@@ -27,6 +27,7 @@ describe('CachingClientWrapper', () => {
       updateContactById: sinon.spy(),
       enrollContactToWorkflow: sinon.spy(),
       currentContactWorkflows: sinon.spy(),
+      getApiUsage: sinon.spy(),
       isDate: sinon.spy(),
       toDate: sinon.spy(),
       toEpoch: sinon.spy(),
@@ -210,6 +211,17 @@ describe('CachingClientWrapper', () => {
       done();
     });
   })
+
+  it('getApiUsage using original function', (done) => {
+    cachingClientWrapperUnderTest = new CachingClientWrapper(clientWrapperStub, redisClientStub, idMap);
+    cachingClientWrapperUnderTest.getAsync = sinon.stub().returns(false);
+    cachingClientWrapperUnderTest.getApiUsage();
+
+    setTimeout(() => {
+      expect(clientWrapperStub.getApiUsage).to.have.been.calledWith();
+      done();
+    });
+  });
 
   it('getCache', (done) => {
     redisClientStub.get = sinon.stub().yields();

--- a/test/client/client-wrapper.ts
+++ b/test/client/client-wrapper.ts
@@ -755,4 +755,35 @@ describe('ClientWrapper', () => {
       expect(hubspotClientStub.crm.imports.coreApi.create).to.have.been.called;
     });
   });
+
+  describe('StatsAware', () => {
+    let hubspotClientStub;
+    let responseObject;
+
+    beforeEach(() => {
+      hubspotClientStub = {
+        apiRequest: sinon.stub()
+      };
+      responseObject = {
+        statusCode: 200,
+        headers: {
+          get: sinon.stub()
+        }
+      }
+
+      hubspotConstructorStub = sinon.stub();
+      hubspotConstructorStub.returns(hubspotClientStub);
+      clientWrapperUnderTest = new ClientWrapper(metadata, hubspotConstructorStub);
+      clientWrapperUnderTest.connectToV3 = sinon.stub();
+      clientWrapperUnderTest.clientV3 = hubspotClientStub;
+    });
+    it('getApiUsage', async () => {
+      hubspotClientStub.apiRequest.resolves(responseObject);
+      await clientWrapperUnderTest.getApiUsage();
+      expect(hubspotClientStub.apiRequest).to.have.been.calledWith({
+        method: 'GET',
+        path: '/integrations/v1/me',
+      });
+    });
+  });
 });

--- a/test/steps/stats/check-api-usage.ts
+++ b/test/steps/stats/check-api-usage.ts
@@ -1,0 +1,74 @@
+import { Struct } from 'google-protobuf/google/protobuf/struct_pb';
+import * as chai from 'chai';
+import { default as sinon } from 'ts-sinon';
+import * as sinonChai from 'sinon-chai';
+import 'mocha';
+
+import { Step as ProtoStep, StepDefinition, RunStepResponse } from '../../../src/proto/cog_pb';
+import { Step } from '../../../src/steps/stats/check-api-usage';
+
+chai.use(sinonChai);
+
+describe('CheckHubspotApiUsageStep', () => {
+  const expect = chai.expect;
+  let protoStep: ProtoStep;
+  let stepUnderTest: Step;
+  let clientWrapperStub: any;
+
+  beforeEach(() => {
+    protoStep = new ProtoStep();
+    clientWrapperStub = sinon.stub();
+    clientWrapperStub.getApiUsage = sinon.stub();
+    stepUnderTest = new Step(clientWrapperStub);
+  });
+
+  it('should return expected step metadata', () => {
+    const stepDef: StepDefinition = stepUnderTest.getDefinition();
+    expect(stepDef.getStepId()).to.equal('CheckHubspotApiUsageStep');
+    expect(stepDef.getName()).to.equal('Check daily HubSpot API usage');
+    expect(stepDef.getExpression()).to.equal('there should be less than 90% usage of your daily HubSpot API limit');
+    expect(stepDef.getType()).to.equal(StepDefinition.Type.VALIDATION);
+  });
+
+  it('should respond with success if the api calls are less than 90% of the daily limit', async () => {
+    clientWrapperStub.getApiUsage.returns(Promise.resolve({
+      limit: 250000,
+      remaining: 200000,
+    }));
+    const response: RunStepResponse = await stepUnderTest.executeStep(protoStep);
+    expect(response.getOutcome()).to.equal(RunStepResponse.Outcome.PASSED);
+  });
+
+  it('should respond with success if the api calls are unlimited', async () => {
+    clientWrapperStub.getApiUsage.returns(Promise.resolve({
+      limit: 'unlimited',
+      remaining: 'unlimited',
+    }));
+    const response: RunStepResponse = await stepUnderTest.executeStep(protoStep);
+    expect(response.getOutcome()).to.equal(RunStepResponse.Outcome.PASSED);
+  });
+
+  it('should respond with a failure if the api calls are more than 90% of the daily limit', async () => {
+    clientWrapperStub.getApiUsage.returns(Promise.resolve({
+      limit: 250000,
+      remaining: 1000,
+    }));
+    const response: RunStepResponse = await stepUnderTest.executeStep(protoStep);
+    expect(response.getOutcome()).to.equal(RunStepResponse.Outcome.FAILED);
+  });
+
+  it('should respond with an error if no usage is found', async () => {
+    clientWrapperStub.getApiUsage.returns(Promise.resolve({
+      success: true,
+    }));
+    const response: RunStepResponse = await stepUnderTest.executeStep(protoStep);
+    expect(response.getOutcome()).to.equal(RunStepResponse.Outcome.ERROR);
+  });
+
+  it('should respond with an error if the marketo client throws an error', async () => {
+    // Cause the client to throw an error, and execute the step.
+    clientWrapperStub.getApiUsage.throws('any error');
+    const response: RunStepResponse = await stepUnderTest.executeStep(protoStep);
+    expect(response.getOutcome()).to.equal(RunStepResponse.Outcome.ERROR);
+  });
+});


### PR DESCRIPTION
- new CheckHubspotApiUsageStep will pass if you have used less than 90% of your daily API calls.
- getApiUsage method on the client wrapper will pull the api limit information from an http request to HubSpot
- new StatsAware mixin
- tests for new step, mixin, and caching client wrapper method.